### PR TITLE
Avoid popping from empty list

### DIFF
--- a/asgi_csrf.py
+++ b/asgi_csrf.py
@@ -208,7 +208,10 @@ async def _parse_form_urlencoded(receive):
         more_body = message.get("more_body", False)
 
     async def replay_receive():
-        return messages.pop(0)
+        if messages:
+            return messages.pop(0)
+        else:
+            return await receive()
 
     return dict(parse_qsl(body.decode("utf-8"))), replay_receive
 


### PR DESCRIPTION
This PR implements the solution proposed by @scott2b in the description of #21:

https://github.com/simonw/asgi-csrf/issues/21#issuecomment-1183411282

I was getting hit with `NS_ERROR_NET_PARTIAL_TRANSFER` when trying to implement CSRF protection on my [fastapi-users](https://fastapi-users.github.io/fastapi-users/12.1/) based application and it turns out that applying the fix suggested in the mentioned comment fixed it for me. The server logs were showing that the error was the same as mentioned in #21

Submitting this as a PR to see if it can gain enough traction to be merged and eventually warranting a new release of asgi-csrf.

fixes #21